### PR TITLE
[BUG FIXED] Distributed SSL training and validation

### DIFF
--- a/nidl/estimators/ssl/yaware.py
+++ b/nidl/estimators/ssl/yaware.py
@@ -217,7 +217,12 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
         )
         self.optimizer_kwargs = optimizer_kwargs
 
-    def training_step(self, batch: Any, batch_idx: int):
+    def training_step(
+        self,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: Optional[int] = 0,
+    ):
         """Perform one training step and computes training loss.
 
         Parameters
@@ -227,9 +232,10 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
             It can be a pair of `torch.Tensor` (V1, V2) or a pair
             ((V1, V2), y) where V1 and V2 are the two views of the same sample
             and y is the auxiliary variable.
-
         batch_idx: int
-            The index of the current batch.
+            The index of the current batch (ignored).
+        dataloader_idx: int, default=0
+            The index of the dataloader (ignored).
 
         Returns
         ----------
@@ -241,8 +247,13 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
             self.projection_head(self.encoder(V1)),
             self.projection_head(self.encoder(V2)),
         )
+        # Gather before computing the contrastive loss.
+        Z1 = self.all_gather_and_flatten(Z1, sync_grads=True)
+        Z2 = self.all_gather_and_flatten(Z2, sync_grads=True)
+        y = self.all_gather_and_flatten(y, sync_grads=True)
+
         loss = self.loss(Z1, Z2, y)
-        self.log("loss/train", loss, prog_bar=True)
+        self.log("loss/train", loss, prog_bar=True, sync_dist=True)
         outputs = {
             "loss": loss,
             "Z1": Z1.cpu().detach(),
@@ -252,7 +263,12 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
         # Returns everything needed for further logging/metrics computation
         return outputs
 
-    def validation_step(self, batch: Any, batch_idx: int):
+    def validation_step(
+        self,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: Optional[int] = 0,
+    ):
         """Perform one validation step and computes validation loss.
 
         Parameters
@@ -262,9 +278,10 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
             It can be a pair of `torch.Tensor` (V1, V2) or a pair
             ((V1, V2), y) where V1 and V2 are the two views of the same
             sample and y is the auxiliary variable.
-
         batch_idx: int
-            The index of the current batch.
+            The index of the current batch (ignored).
+        dataloader_idx: int, default=0
+            The index of the dataloader (ignored).
         """
 
         V1, V2, y = self.parse_batch(batch)
@@ -272,6 +289,10 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
             self.projection_head(self.encoder(V1)),
             self.projection_head(self.encoder(V2)),
         )
+        Z1 = self.all_gather_and_flatten(Z1, sync_grads=False)
+        Z2 = self.all_gather_and_flatten(Z2, sync_grads=False)
+        y = self.all_gather_and_flatten(y, sync_grads=False)
+
         val_loss = self.loss(Z1, Z2, y)
         outputs = {
             "loss": val_loss,
@@ -279,7 +300,7 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
             "Z2": Z2.cpu().detach(),
             "y_true": y.cpu().detach() if y is not None else None,
         }
-        self.log("loss/val", val_loss, prog_bar=True)
+        self.log("loss/val", val_loss, prog_bar=True, sync_dist=True)
         # Returns everything needed for further logging/metrics computation
         return outputs
 
@@ -289,6 +310,27 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
         batch_idx: int,
         dataloader_idx: Optional[int] = 0,
     ):
+        """Encode the input data into the latent space.
+
+        Importantly, we do not apply the projection head here since it is
+        not part of the final model at inference time (only used for training).
+
+        Parameters
+        ----------
+        batch: torch.Tensor
+            A batch of data that has been generated from `test_dataloader`.
+            This is given as is to the encoder.
+        batch_idx: int
+            The index of the current batch (ignored).
+        dataloader_idx: int, default=0
+            The index of the dataloader (ignored).
+
+        Returns
+        ----------
+        features: torch.Tensor
+            The encoded features returned by the encoder.
+
+        """
         return self.encoder(batch)
 
     def parse_batch(
@@ -395,6 +437,39 @@ class YAwareContrastiveLearning(TransformerMixin, BaseEstimator):
             return optimizer
         else:
             return [optimizer], [scheduler]
+
+    def all_gather_and_flatten(
+        self, tensor: Union[torch.Tensor, None], **kwargs
+    ):
+        """Gathers the tensor from all devices and flattens batch dimension.
+
+        This is useful when gathering tensors without adding extra dimensions.
+        It handles some edge cases, such as when using a single GPU.
+
+        Parameters
+        ----------
+        tensor: torch.Tensor or None
+            The tensor to gather. If None, it is returned as is.
+        **kwargs: dict
+            Additional keyword arguments for `self.all_gather`.
+
+        Returns
+        -------
+        tensor: torch.Tensor
+            The gathered and flattened tensor.
+        """
+        if tensor is None:
+            return tensor
+        if not isinstance(tensor, torch.Tensor):
+            raise ValueError(
+                f"tensor must be a torch.Tensor, got {type(tensor)}"
+            )
+        if self.trainer is None or self.trainer.world_size == 1:
+            return tensor
+        gathered = self.all_gather(tensor, **kwargs)
+        # Reshape to (batch_size * world_size, *)
+        gathered = gathered.reshape(-1, *gathered.shape[2:])
+        return gathered
 
     def _build_encoder(
         self,

--- a/nidl/tests/test_estimator.py
+++ b/nidl/tests/test_estimator.py
@@ -7,11 +7,14 @@
 ##########################################################################
 
 from collections import OrderedDict
+from types import SimpleNamespace
 
 import unittest
+from unittest.mock import patch
 
 import torch
 from torch import nn
+import torch.optim as optim
 from torch.utils.data import Dataset, DataLoader
 from torchvision import transforms
 
@@ -28,6 +31,28 @@ from nidl.estimators.linear import LogisticRegression
 from nidl.losses.yaware_infonce import KernelMetric
 from nidl.transforms import MultiViewsTransform
 from nidl.utils import print_multicolor
+
+
+class CustomTensorDataset(Dataset):
+    """TensorDataset with support of transforms."""
+
+    def __init__(self, data, labels=None, transform=None):
+        self.data = data
+        self.labels = labels
+        self.transform = transform
+
+    def __getitem__(self, index):
+        x = self.data[index]
+        if self.transform:
+            x = self.transform(x)
+        if self.labels is not None:
+            y = self.labels[index]
+            return x, y
+        else:
+            return x
+
+    def __len__(self):
+        return len(self.data)
 
 
 class TestEstimators(unittest.TestCase):
@@ -241,26 +266,225 @@ class TestEstimators(unittest.TestCase):
             self.assertTrue(pred.shape == (self.n_images, 2))
 
 
-class CustomTensorDataset(Dataset):
-    """TensorDataset with support of transforms."""
+class DummyEncoder(nn.Module):
+    """Very small encoder that returns a fixed-sized vector per sample and exposes .latent_size."""
+    def __init__(self, latent_size=16):
+        super().__init__()
+        self.latent_size = latent_size
+        # simple linear mapping from flattened image to latent
+        self.backbone = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(8 * 8 * 1, latent_size)
+        )
+        # initialize weights deterministically for reproducibility
+        torch.manual_seed(0)
+        for p in self.backbone.parameters():
+            nn.init.constant_(p, 0.01)
 
-    def __init__(self, data, labels=None, transform=None):
-        self.data = data
-        self.labels = labels
-        self.transform = transform
+    def forward(self, x):
+        return self.backbone(x)
 
-    def __getitem__(self, index):
-        x = self.data[index]
-        if self.transform:
-            x = self.transform(x)
-        if self.labels is not None:
-            y = self.labels[index]
-            return x, y
+class DummySSLDataset(CustomTensorDataset):
+
+    def __init__(self, n_images=20):
+        self.fake_data = torch.rand(n_images, 8 * 8)
+        ssl_transforms = transforms.Compose([lambda x: x + torch.rand(x.size())])
+        super().__init__(
+            self.fake_data, transform=MultiViewsTransform(ssl_transforms, n_views=2)
+        )
+
+class SimpleSimCLRTestMixin:
+    """Utilities for testcases to create a SimCLR object."""
+    def make_simclr(
+            self, latent_size=16, hidden_dims=[32, 8], 
+            lr=1e-3, temperature=0.1, weight_decay=0.0,
+            world_size=1, fitted=False):
+        encoder = DummyEncoder(latent_size=latent_size)
+        sim = SimCLR(
+            encoder=encoder,
+            hidden_dims=hidden_dims,
+            lr=lr,
+            temperature=temperature,
+            weight_decay=weight_decay,
+            random_state=0,
+            max_epochs=2,
+            devices=world_size,
+            accelerator="cpu"
+        )
+        if fitted:
+            dataset = DummySSLDataset()
+            dataloader = DataLoader(dataset, batch_size=2, shuffle=False)
+            sim.fit(dataloader)
+        return sim
+
+
+class TestSimCLRBasic(unittest.TestCase, SimpleSimCLRTestMixin):
+    def test_constructor_invalid_temperature_raises(self):
+        encoder = DummyEncoder(latent_size=8)
+        with self.assertRaises(AssertionError):
+            SimCLR(
+                encoder=encoder, hidden_dims=[16], 
+                lr=1e-3, temperature=0.0, weight_decay=0.0
+            )
+
+    def test_constructor_encoder_without_latent_size_raises(self):
+        class BadEnc(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x):
+                return x
+        with self.assertRaises(AssertionError):
+            SimCLR(
+                encoder=BadEnc(), hidden_dims=[16], lr=1e-3, 
+                temperature=0.1, weight_decay=0.0)
+
+    def test_all_gather_and_flatten_non_tensor_raises(self):
+        sim = self.make_simclr()
+        with self.assertRaises(ValueError):
+            sim.all_gather_and_flatten("not a tensor")
+
+    def test_all_gather_and_flatten_single_device_returns_same_tensor(self):
+        sim = self.make_simclr(world_size=1, fitted=True)
+
+        x = torch.randn(3, sim.f.latent_size)
+        out2 = sim.all_gather_and_flatten(x)
+        self.assertTrue(torch.allclose(out2, x))
+
+    def test_all_gather_and_flatten_multi_device_flattening(self):
+        # Create simclr and monkeypatch all_gather to return stacked tensors
+        sim = self.make_simclr(world_size=2, fitted=True)
+        batch = 3
+        feat = sim.f.latent_size
+        z = torch.randn(batch, feat)
+
+        def fake_all_gather(tensor, **kwargs):
+            # return simulated gathered tensor shaped (world_size, batch, feat)
+            return torch.stack([tensor, tensor], dim=0)
+
+        sim.all_gather = fake_all_gather
+        out = sim.all_gather_and_flatten(z)
+        # expected shape is (world_size * batch, feat)
+        self.assertEqual(out.shape, (2 * batch, feat))
+        # check that first batch matches original
+        self.assertTrue(torch.allclose(out[:batch], z))
+
+    def test_configure_optimizers_without_scheduler(self):
+        sim = self.make_simclr()
+        # ensure no hparams.max_epochs present
+        if hasattr(sim, "hparams"):
+            # remove max_epochs if it exists
+            try:
+                delattr(sim.hparams, "max_epochs")
+            except Exception:
+                pass
+        res = sim.configure_optimizers()
+        self.assertIsInstance(res, list)
+        # should return one-element list (optimizers) or [optimizer]
+        self.assertGreaterEqual(len(res), 1)
+
+    def test_configure_optimizers_with_scheduler(self):
+        sim = self.make_simclr()
+        res = sim.configure_optimizers()
+        # Expect [optimizer], [scheduler]
+        self.assertTrue(isinstance(res, tuple) or isinstance(res, list))
+        # The function returns either [opt] or ([opt],[sched]); we check for scheduler return shape
+        # if a scheduler is returned we expect outer list of length 2
+        if isinstance(res, list) and len(res) == 2 and all(isinstance(x, list) for x in res):
+            # good: [optimizer], [lr_scheduler]
+            self.assertTrue(len(res[0]) >= 1 and len(res[1]) >= 1)
         else:
-            return x
+            # In some environments the code may return ([opt], [sched]) as a tuple; accept that
+            self.assertTrue(True)
 
-    def __len__(self):
-        return len(self.data)
+    def test_transform_step_returns_encoder_output(self):
+        sim = self.make_simclr()
+        # create small "image" shaped input consistent with DummyEncoder (expects 8x8x1)
+        batch = torch.randn(2, 1, 8, 8)
+        out = sim.transform_step(batch, batch_idx=0)
+        # Should be the encoder output: shape (2, latent_size)
+        self.assertEqual(out.shape, (2, sim.f.latent_size))
+
+
+class TestSimCLRSteps(unittest.TestCase, SimpleSimCLRTestMixin):
+    def setUp(self):
+        self.sim = self.make_simclr(
+            latent_size=8, hidden_dims=[16, 8], 
+            lr=1e-3, temperature=0.1, fitted=True
+        )
+
+    def test_training_step_returns_expected_loss_and_embeddings(self):
+        sim = self.sim
+        sim.log = lambda *a, **k: None
+        # Create toy views V1 and V2: small 8x8 images
+        batch_size = 4
+        V1 = torch.randn(batch_size, 1, 8, 8)
+        V2 = torch.randn(batch_size, 1, 8, 8)
+        outputs = sim.training_step((V1, V2), batch_idx=0)
+        # The loss is DeterministicInfoNCE: mean squared difference between Z1 and Z2
+        self.assertIn("loss", outputs)
+        self.assertIn("Z1", outputs)
+        self.assertIn("Z2", outputs)
+
+        # Z1, Z2 shapes: (batch, proj_dim).
+        self.assertEqual(outputs["Z1"].shape, (batch_size, sim.f.latent_size))
+        self.assertEqual(outputs["Z2"].shape, (batch_size, sim.f.latent_size))
+        # Check loss numeric equality with a direct computation using sim.loss
+        # outputs['Z1'] and 'Z2' came back on cpu detached
+        z1 = outputs["Z1"]
+        z2 = outputs["Z2"]
+        expected_loss = sim.loss(z1, z2)
+        # loss returned in outputs might be a tensor; compare floats
+        self.assertAlmostEqual(float(outputs["loss"]), float(expected_loss), places=6)
+
+    def test_validation_step_behavior(self):
+        sim = self.sim
+        sim.log = lambda *a, **k: None
+        batch_size = 3
+        V1 = torch.randn(batch_size, 1, 8, 8)
+        V2 = torch.randn(batch_size, 1, 8, 8)
+        outputs = sim.validation_step((V1, V2), batch_idx=0)
+        self.assertIn("loss", outputs)
+        self.assertIn("Z1", outputs)
+        self.assertIn("Z2", outputs)
+        # shapes should match
+        self.assertEqual(outputs["Z1"].shape, (batch_size, sim.f.latent_size))
+        self.assertEqual(outputs["Z2"].shape, (batch_size, sim.f.latent_size))
+
+    def test_training_step_multi_device_collects_and_flattens(self):
+        sim = self.make_simclr(
+            latent_size=8, hidden_dims=[16, 8], 
+            lr=1e-3, temperature=0.1, world_size=2,
+            fitted=True)
+        sim.log = lambda *a, **k: None
+        batch_size = 2
+        V1 = torch.randn(batch_size, 1, 8, 8)
+        V2 = torch.randn(batch_size, 1, 8, 8)
+
+        outputs = sim.training_step((V1, V2), batch_idx=0)
+
+        z1 = outputs["Z1"]
+        z2 = outputs["Z2"]
+        self.assertEqual(z1.shape, (2 * batch_size, sim.f.latent_size))
+        self.assertEqual(z2.shape, (2 * batch_size, sim.f.latent_size))
+
+        expected_loss = float(sim.loss(z1, z2))
+        self.assertAlmostEqual(float(outputs["loss"]), expected_loss, places=6)
+
+    def test_zero_batch_size_handling(self):
+        """
+        Ensure the steps don't crash on zero-size batch (edge case).
+        Many dataloaders might never emit this, but code should handle gracefully if it occurs.
+        """
+        sim = self.sim
+        sim.log = lambda *a, **k: None
+        V1 = torch.empty(0, 1, 8, 8)
+        V2 = torch.empty(0, 1, 8, 8)
+        outputs_train = sim.training_step((V1, V2), batch_idx=0)
+        self.assertIn("loss", outputs_train)
+        self.assertIsInstance(outputs_train["loss"], torch.Tensor)
+        outputs_val = sim.validation_step((V1, V2), batch_idx=0)
+        self.assertIn("loss", outputs_val)
+        self.assertIsInstance(outputs_val["loss"], torch.Tensor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current SimCLR and y-Aware CL estimators do not handle the distributed multi-gpu settings in torch (the contrastive loss should be applied to the entire batch and not by device). This PR corrects this bug. It also clarifies the documentation of SimCLR (e.g. for training/validation steps) and the training/validation steps in SimCLR returns all the tensors computed during training for further metrics computations in callbacks. 