### PR TITLE
[BUG FIXED] Documentation deployment in CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -63,9 +63,6 @@ jobs:
       run: |
         cd ./doc
         make html-strict
-        ls source/_static
-        ls build/html/_static
-        cp -r source/_static/* build/html/_static
         cd ..
     - name: Upload documentation as an artifact
       uses: actions/upload-artifact@v4
@@ -73,12 +70,12 @@ jobs:
         name: html-documentation
         retention-days: 15
         path: |
-            doc/build/html
+            doc/_build/html
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: doc/build/html
+        publish_dir: doc/_build/html
         destination_dir: dev
 
   build:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -187,7 +187,7 @@ linkcheck_ignore = [
     # give a 403 Client Error: Forbidden for url:
     r"https://sites.wustl.edu/oasisbrains/.*",
     # similarly below are publishers that do not like doi redirects:
-    r"https://doi.org/.*"
+    r"https://doi.org/.*",
 ]
 
 linkcheck_exclude_documents = [r".*/sg_execution_times.rst"]
@@ -288,7 +288,7 @@ html_favicon = "logos/favicon.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["images", "themes"]
+html_static_path = ["images", "themes", "_static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -426,6 +426,8 @@ def setup(app):
 # -- sphinxext.opengraph configuration -------------------------------------
 
 ogp_site_url = "https://neurospin-deepinsight.github.io/nidl"
-ogp_image = "https://neurospin-deepinsight.github.io/nidl/_static/nidl-logo.png"
+ogp_image = (
+    "https://neurospin-deepinsight.github.io/nidl/_static/nidl-logo.png"
+)
 ogp_use_first_image = True
 ogp_site_name = "Nidl"


### PR DESCRIPTION
The following code lines in *documentation.yml* are never tested in CI and they contain a bug:

```bash
build_and_deploy:
...
ls source/_static
ls build/html/_static
cp -r source/_static/* build/html/_static
```

The *source* folder does not exist on the server. This PR intends to fix this bug by letting Sphinx handle automatically the copy rather than doing it by hand. I think a pseudo-deployment should be tested in Github actions too before merging the PRs, maybe a feature to add ? 
