### PR TITLE
[BUGS FIXED] Small bugs fixed

### DIFF
--- a/nidl/datasets/openbhb.py
+++ b/nidl/datasets/openbhb.py
@@ -93,6 +93,14 @@ class OpenBHB(Dataset):
         Warning: setting `max_workers` > 1 can raise Hugging Face 429 errors
         (too many requests). We recommend keeping this value low.
 
+    mmap_mode : {None, 'r+', 'r', 'w+', 'c'}, default='r'
+        If not None, then memory-map the NumPy arrays, using the given mode (see
+        `numpy.memmap` for a detailed description of the modes).  A
+        memory-mapped array is kept on disk. However, it can be accessed
+        and sliced like any ndarray.  Memory mapping is especially useful
+        for accessing small fragments of large files without reading the
+        entire file into memory.
+
     transforms : callable or None, default=None
         A function/transform that takes in a brain image and returns a
         transformed version. Input depends on `modality` and can be a 3D image,
@@ -161,6 +169,7 @@ class OpenBHB(Dataset):
         split: str = "train",
         streaming: bool = True,
         max_workers: int = 1,
+        mmap_mode: Optional[str] = "r",
         transforms: Optional[Callable] = None,
         target_transforms: Optional[Callable] = None,
     ):
@@ -171,7 +180,7 @@ class OpenBHB(Dataset):
         self.streaming = streaming
         self.transforms = transforms
         self.target_transforms = target_transforms
-
+        self.mmap_mode = mmap_mode
         self.samples = self.make_dataset(self.split)
         if not self.streaming:  # fetch all data split if not there
             self.download_dataset_split(
@@ -717,7 +726,7 @@ class OpenBHB(Dataset):
             row = row.drop(columns=["participant_id", "session"]).to_numpy()
             return row.reshape(shape).astype(np.float32)
         else:
-            return np.load(path)[0].astype(np.float32)
+            return np.load(path, mmap_mode=self.mmap_mode)[0].astype(np.float32)
 
     def _parse_root(self, path):
         # eventually parse "~" or $HOME

--- a/nidl/datasets/openbhb.py
+++ b/nidl/datasets/openbhb.py
@@ -94,8 +94,8 @@ class OpenBHB(Dataset):
         (too many requests). We recommend keeping this value low.
 
     mmap_mode : {None, 'r+', 'r', 'w+', 'c'}, default='r'
-        If not None, then memory-map the NumPy arrays, using the given mode (see
-        `numpy.memmap` for a detailed description of the modes).  A
+        If not None, then memory-map the NumPy arrays, using the given mode
+        (see `numpy.memmap` for a detailed description of the modes).  A
         memory-mapped array is kept on disk. However, it can be accessed
         and sliced like any ndarray.  Memory mapping is especially useful
         for accessing small fragments of large files without reading the
@@ -726,7 +726,8 @@ class OpenBHB(Dataset):
             row = row.drop(columns=["participant_id", "session"]).to_numpy()
             return row.reshape(shape).astype(np.float32)
         else:
-            return np.load(path, mmap_mode=self.mmap_mode)[0].astype(np.float32)
+            return np.load(
+                path, mmap_mode=self.mmap_mode)[0].astype(np.float32)
 
     def _parse_root(self, path):
         # eventually parse "~" or $HOME

--- a/nidl/metrics/ssl.py
+++ b/nidl/metrics/ssl.py
@@ -409,7 +409,7 @@ def procrustes_similarity(X, Y) -> float:
     if torch.isclose(
         nx * ny, torch.Tensor([0.0]).to(dtype=X.dtype, device=X.device)
     ):
-        sim = torch.Tensor(0.0).to(dtype=X.dtype, device=X.device)
+        sim = torch.tensor(0.0).to(dtype=X.dtype, device=X.device)
     else:
         # Cross-covariance-like matrix
         M = Xc.T @ Yc  # shape (d1, d2)
@@ -498,7 +498,7 @@ def procrustes_r2(X, Y) -> float:
     if torch.isclose(
         torch.norm(Yc, p="fro"), torch.tensor(0.0, dtype=X.dtype)
     ):
-        sim = torch.Tensor(0.0).to(dtype=X.dtype, device=X.device)
+        sim = torch.tensor(0.0).to(dtype=X.dtype, device=X.device)
     else:
         # SVD-based orthogonal Procrustes
         M = Xc.T @ Yc

--- a/nidl/transforms.py
+++ b/nidl/transforms.py
@@ -440,6 +440,6 @@ class VolumeTransform(Transform):
         if len(data.shape) not in [3, 4]:
             raise ValueError(
                 "Input data must be 3d or 4d (channel+spatial dimensions), "
-                f"got {len(data.shape)}"
+                f"got {data.shape}"
             )
         return data

--- a/nidl/volume/backbones/vit3d.py
+++ b/nidl/volume/backbones/vit3d.py
@@ -186,9 +186,9 @@ class VisionTransformer3D(nn.Module):
     Parameters
     ----------
     img_size : int or sequence of int
-        Input size in ``(D, H, W)``.
+        Input size in ``(H, W, D)``.
     patch_size : int or sequence of int
-        Patch size in ``(D, H, W)``.
+        Patch size in ``(H, W, D)``.
     in_chans : int, default=1
         Number of input channels.
     num_classes : int, default=0


### PR DESCRIPTION
This PR fixes the following bugs:
- Docstring is now consistent in ViT3D for (H, W, D) ordering
- Error message fixed in VolumeTransform
- Similarity Procrustes metric edge case fixed
-  (improvement) Numpy loading of (large) arrays in OpenBHB accepts memory mapping 