### PR TITLE
Base transform exposed

### DIFF
--- a/nidl/transforms/__init__.py
+++ b/nidl/transforms/__init__.py
@@ -1,0 +1,14 @@
+##########################################################################
+# NSAp - Copyright (C) CEA, 2025
+# Distributed under the terms of the CeCILL-B license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+# for details.
+##########################################################################
+
+from .transforms import (
+    Identity,
+    MultiViewsTransform,
+    Transform,
+    VolumeTransform,
+)


### PR DESCRIPTION
Accessing of `nidl.transforms.transforms.Transform` through `nidl.transforms.Transform` (much more intuitive).