### PR TITLE
docs: fix README gallery link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ If no error is raised, you have installed nidl correctly.
 Where to start
 ==============
 
-Examples are available in the `gallery <https://neurospin-deepinsight.github.io/nidl/auto_gallery/index.html>`_.
+Examples are available in the `gallery <https://neurospin-deepinsight.github.io/nidl/auto_examples/index.html>`_.
 
 
 Dependencies


### PR DESCRIPTION
## Summary

- point the README gallery link at the published `auto_examples` page
- replace the URL that currently returns HTTP 404

Fixes #69

## Testing

- `rstcheck --ignore-languages bash README.rst`
- `ruff check nidl`
- `python -m build --outdir /tmp/nidl-pr69-dist-20260724`
- `twine check /tmp/nidl-pr69-dist-20260724/*`
- live URL check: replacement returned HTTP 200; old URL returned HTTP 404
